### PR TITLE
ZkSync local mock

### DIFF
--- a/mock-server/README.md
+++ b/mock-server/README.md
@@ -1,0 +1,34 @@
+## ZkSync mock server
+
+A mocked zkSync server that supports the minimal set of operations needed for basic PoC scenario.
+    
+#### Setup 
+```
+$ cd mock-server
+$ python3 -m venv .venv
+$ . .venv/bin/activate
+$ pip install -r requirements.txt
+```
+----
+
+#### Running
+
+Before starting the server start a Docker container with Ganache and
+mocked zkSync contract:
+
+```
+$ docker run -d --rm -ti -p 8545:8545 --name docker_ethereum \
+    docker.pkg.github.com/golemfactory/gnt2/gnt2-docker-yagna:latest
+```
+
+Run the server:
+```
+$ python mock_server.py
+```
+
+----
+#### Testing
+```
+$ cd poc.js
+$ yarn ganache
+```

--- a/mock-server/mock_server.py
+++ b/mock-server/mock_server.py
@@ -1,0 +1,146 @@
+from werkzeug.wrappers import Request, Response
+from werkzeug.serving import run_simple
+
+from jsonrpc import JSONRPCResponseManager, dispatcher
+
+from web3.auto import w3
+
+w3.eth.defaultAccount = w3.eth.accounts[0]
+
+ZKSYNC_ADDRESS = "0x94BA4d5Ebb0e05A50e977FFbF6e1a1Ee3D89299c"
+ZKSYNC_MIN_ABI = [
+    {
+        "constant": False,
+        "inputs": [
+            {"name": "_token", "type": "address"},
+            {"name": "_amount", "type": "uint128"},
+            {"name": "_addr","type": "address"}
+        ],
+        "name": "withdrawERC20",
+        "outputs": [],
+        "payable": False,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]
+ZKSYNC = w3.eth.contract(address=ZKSYNC_ADDRESS, abi=ZKSYNC_MIN_ABI)
+
+NGNT_ADDRESS = "0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34"
+NGNT_MNI_ABI = [
+  {
+    "constant": True,
+    "inputs": [{"name": "_owner", "type": "address"}],
+    "name": "balanceOf",
+    "outputs": [{"name": "balance", "type": "uint256"}],
+    "type": "function"
+  }
+]
+NGNT = w3.eth.contract(address=NGNT_ADDRESS, abi=NGNT_MNI_ABI)
+
+
+@dispatcher.add_method
+def contract_address():
+    print("contract_address()")
+    return {
+        "mainContract": ZKSYNC_ADDRESS,
+        "govContract": ""
+    }
+
+
+@dispatcher.add_method
+def tokens():
+    print("tokens()")
+    return {
+        "GNT": {
+            "address": NGNT_ADDRESS,
+            "id": 16,
+            "symbol": "GNT",
+            "decimals": 18
+        }
+    }
+
+
+@dispatcher.add_method
+def account_info(address):
+    print(f"account_info({address})")
+    ngnt_balance = str(NGNT.caller.balanceOf(ZKSYNC_ADDRESS))
+    return {
+        "address": address,
+        "id": 1,
+        "committed": {
+            "balances": {
+                "GNT": ngnt_balance,
+            },
+            "nonce": 0,
+        },
+        "depositing": {
+            "balances": {}
+        },
+        "verified": {
+            "balances": {
+                "GNT": ngnt_balance,
+            },
+            "nonce": 0,
+        }
+    }
+
+
+@dispatcher.add_method
+def get_tx_fee(tx_type, *args):
+    print(f"transaction_fee{(tx_type,) + args}")
+    return {
+        "feeType": tx_type,
+        "gasTxAmount": "0",
+        "gasPriceWei": "0",
+        "gasFee": "0",
+        "zkpFee": "0",
+        "totalFee": "0",
+    }
+
+
+@dispatcher.add_method
+def tx_submit(params, signature):
+    print(f"submit_tx({params}, {signature})")
+    if params["type"] == "Withdraw":
+        tx_hash = ZKSYNC.functions.withdrawERC20(NGNT_ADDRESS, int(params["amount"]), params["to"]).transact()
+        return tx_hash.hex()
+    return "0x00000000000000000000000000000000000000000000000000000000deadbeef"
+
+
+@dispatcher.add_method
+def tx_info(tx_hash):
+    print(f"tx_info({tx_hash})")
+    return {
+        "executed": True,
+        "success": True,
+        "block": {
+          "blockNumber": 1,
+          "committed": True,
+          "verified": True
+        }
+    }
+
+
+@dispatcher.add_method
+def ethop_info(*args):
+    print(f"ethop_info{args}")
+    return {
+        "executed": True,
+        "success": True,
+        "failReason": "",
+        "block": {
+            "blockNumber": 0,
+            "committed": True,
+            "verified": True,
+        }
+    }
+
+
+@Request.application
+def application(request: Request):
+    response = JSONRPCResponseManager.handle(request.data, dispatcher)
+    return Response(response.json, mimetype='application/json')
+
+
+if __name__ == '__main__':
+    run_simple('localhost', 3030, application)

--- a/mock-server/requirements.txt
+++ b/mock-server/requirements.txt
@@ -1,0 +1,3 @@
+json-rpc==1.13.0
+web3==5.12.1
+Werkzeug==1.0.1

--- a/poc.js/package.json
+++ b/poc.js/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "basic": "node src/basic.js",
+    "ganache": "WEB3_URL=http://localhost:8545 ZKSYNC_PROVIDER_URL=http://localhost:3030 GNT_CONTRACT_ADDRESS=0xFDFEF9D10d929cB3905C71400ce6be1990EA0F34 node src/basic.js -r 0x29f3edee0ad3abf8e2699402e0e28cd6492c9be7eaab00d732a791c33552f797 -p 0x5c8b9227cd5065c7e3f6b73826b8b42e198c4497f6688e3085d5ab3a6d520e74",
     "exodus": "node src/basic.js --exodus",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Implemented a mock zkSync server that supports the minimal set of operations needed for basic PoC scenario.

Setup:
```
$ cd mock-server
$ python3 -m venv .venv
$ . .venv/bin/activate
$ pip install -r requirements.txt
```

Before starting the server start a Docker container with Ganache and mocked zkSync contract:

```
$ docker run -d --rm -ti -p 8545:8545 --name docker_ethereum \
    docker.pkg.github.com/golemfactory/gnt2/gnt2-docker-yagna:latest
```

Run the server:
```
$ python mock_server.py
```

For testing, run the PoC script with mocked env:
```
$ cd poc.js
$ yarn ganache
```