### PR TITLE
Mock server: retry web3 initialization

### DIFF
--- a/mock-server/requirements.txt
+++ b/mock-server/requirements.txt
@@ -1,3 +1,4 @@
 Flask==1.1.2
 json-rpc==1.13.0
+retrying==1.3.3
 web3==5.12.1


### PR DESCRIPTION
Initializing web3 accounts and contracts requires Ganache to be fully initialized first. This leads to race conditions. Therefore, whole
initialization has been moved to separate function wrapped in a `@retry` to wait for Ganache.